### PR TITLE
Add support to get a specific direct debit mandate

### DIFF
--- a/src/entities/mandate.js
+++ b/src/entities/mandate.js
@@ -34,6 +34,22 @@ class Mandate {
     });
   }
 
+    /**
+   * Gets a specific direct debit mandate
+   * @param {string} accessToken - the oauth bearer token.
+   * @return {Promise} - the http request promise
+   */
+  getMandate (accessToken, mandateId) {
+    typeValidation(arguments, getMandateParameterDefinition);
+    const url = `${this.options.apiUrl}/api/v1/direct-debit/mandates/${mandateId}`;
+    log(`GET ${url}`);
+    return axios({
+      method: 'GET',
+      url,
+      headers: defaultHeaders(accessToken)
+    });
+  }
+
   /**
    * Deletes specific direct debit mandate
    * @param {string} accessToken - the oauth bearer token.
@@ -54,6 +70,11 @@ class Mandate {
 
 const listMandatesParameterDefinition = [
   {name: 'accessToken', validations: ['required', 'string']}
+];
+
+const getMandateParameterDefinition = [
+  {name: 'accessToken', validations: ['required', 'string']},
+  {name: 'mandateId', validations: ['required', 'string']}  
 ];
 
 const deleteMandateParameterDefinition = [

--- a/src/starling.js
+++ b/src/starling.js
@@ -131,6 +131,16 @@ class Starling {
     return this.mandate.listMandates(accessToken);
   }
 
+   /**
+   * Gets a specific direct debit mandate
+   * @param {string} accessToken - the oauth bearer token.
+   * @param {string} mandateId - the unique mandate ID
+   * @return {Promise} - the http request promise
+   */
+  getMandate (accessToken = this.config.accessToken, mandateId) {
+    return this.mandate.getMandate(accessToken, mandateId);
+  }
+
   /**
    * Deletes specific direct debit mandate
    * @param {string} accessToken - the oauth bearer token.

--- a/test/entities/mandate.spec.js
+++ b/test/entities/mandate.spec.js
@@ -7,6 +7,7 @@ const log = debug('starling:mandate-test');
 
 import Starling from '../../src/starling';
 import listMandatesResponse from '../responses/v1-list-mandates.json';
+import getMandateResponse from '../responses/v1-get-mandate.json'
 
 describe('List Mandates', function () {
   this.timeout(30 * 1000);
@@ -43,11 +44,34 @@ describe('List Mandates', function () {
 
   const mandateId = '12345-12345';
 
-  nock('http://localhost:8080', expectAuthorizationHeader(accessToken))
+  it('should get the specified mandate', function (done) {
+    
+        nock('http://localhost:8080', expectAuthorizationHeader(accessToken))
+        .get(`/api/v1/direct-debit/mandates/${mandateId}`)
+        .reply(200, getMandateResponse);
+    
+        starlingCli
+          .getMandate(accessToken, mandateId)
+          .then(function ({ data }) {
+            expect(data.uid).to.be("0931e8a3-7b4a-4c2d-9729-df2296dde98");
+            expect(data.reference).to.be("747338448");
+            expect(data.status).to.be("LIVE");
+            expect(data.source).to.be("ELECTRONIC");
+            expect(data.created).to.be("2017-02-21T08:53:26.144Z");
+            expect(data.originatorName).to.be("AFFINITY WATER LTD");
+            expect(data.originatorUid).to.be("c44adbfe-779b-4afe-b03f-a861db75ab78");
+            log(JSON.stringify(data));
+            done();
+          })
+          .catch(done);
+      });
+
+  it('should delete the specified mandate', function (done) {
+
+    nock('http://localhost:8080', expectAuthorizationHeader(accessToken))
     .delete(`/api/v1/direct-debit/mandates/${mandateId}`)
     .reply(204);
 
-  it('should delete the specified mandate', function (done) {
     starlingCli
       .deleteMandate(accessToken, mandateId)
       .then(function ({ status }) {

--- a/test/responses/v1-get-mandate.json
+++ b/test/responses/v1-get-mandate.json
@@ -1,0 +1,9 @@
+{
+  "uid": "0931e8a3-7b4a-4c2d-9729-df2296dde98",
+  "reference": "747338448",
+  "status": "LIVE",
+  "source": "ELECTRONIC",
+  "created": "2017-02-21T08:53:26.144Z",
+  "originatorName": "AFFINITY WATER LTD",
+  "originatorUid": "c44adbfe-779b-4afe-b03f-a861db75ab78"
+}


### PR DESCRIPTION
The direct debit mandate endpoint GET /api/v1/direct-debit/mandates/{mandateUid} is not covered in the SDK. Added support for this, including test coverage.

