### PR TITLE
:memo: Fix typo in readme and update links to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![npm version](https://badge.fury.io/js/starling-developer-sdk.svg)](https://www.npmjs.com/package/starling-developer-sdk)
 ## Documentation
 
-The documentation for our SDK can be found <a href="https://starlingbank.github.io/starling-developer-sdk/">here</a>.
+The documentation for our SDK can be found [here](https://starlingbank.github.io/starling-developer-sdk/).
 
 
 ## Installation
@@ -16,7 +16,7 @@ $ npm install --save starling-developer-sdk
 ```javascript
 const Starling = require('starling-developer-sdk');
 // or 
-import Starling from 'starling-developer-sk'
+import Starling from 'starling-developer-sdk'
 const client = new Starling({
     accessToken: '<oauth access token>'
 });
@@ -53,4 +53,4 @@ $ bundle install
 $ bundle exec jekyll serve
 ```
 
-This depends on ruby and bundler (see <a href="https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/"> here</a> for more info on Jekyll and Github Pages)
+This depends on ruby and bundler (see [here](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll) for more info on Jekyll and Github Pages)


### PR DESCRIPTION
Fixed a typo where the 'd' was missing from 'sdk' in the import example