### PR TITLE
🔒 Update default OAuth token exchange URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ const Starling = require('starling-developer-sdk')
 import Starling from 'starling-developer-sdk'
 
 const client = new Starling({
+  // apiUrl: 'https://api-sandbox.starlingbank.com',
   accessToken: '<oauth access token>'
 })
 

--- a/src/entities/oauth.js
+++ b/src/entities/oauth.js
@@ -54,16 +54,16 @@ class OAuth {
 
   /**
    * Gets the access token from the starling OAuth endpoint
-   * @param {string} parameters.oauthUrl - the OAuth url
+   * @param {string} parameters.apiUrl - the OAuth url
    * @param {object} parameters.queryParams - the query params passed to the OAuth endpoint as per the OAuth spec
    * @return {Promise} - the http request promise
    */
   getOAuthToken (parameters) {
     parameters = Object.assign({}, this.options, parameters)
     getOAuthTokenParameterValidator(parameters)
-    const { oauthUrl, queryParams } = parameters
+    const { apiUrl, queryParams } = parameters
 
-    const url = `${oauthUrl}/oauth/access-token`
+    const url = `${apiUrl}/oauth/access-token`
     log(`POST ${url} queryParams:${JSON.stringify(queryParams)}`)
 
     return axios({
@@ -79,7 +79,7 @@ class OAuth {
 }
 
 const getOAuthTokenParameterValidator = struct.interface({
-  oauthUrl: 'string',
+  apiUrl: 'string',
   queryParams: struct.union([
     struct.object({
       client_id: 'string',

--- a/src/starling.js
+++ b/src/starling.js
@@ -31,7 +31,6 @@ class Starling {
   constructor (options) {
     const defaults = {
       apiUrl: 'https://api.starlingbank.com',
-      oauthUrl: 'https://oauth.starlingbank.com',
       clientId: '',
       clientSecret: ''
     }

--- a/test/oauth.spec.js
+++ b/test/oauth.spec.js
@@ -8,7 +8,7 @@ const log = debug('starling:oauth-test')
 
 describe('OAuth', () => {
   const starlingCli = new Starling({
-    oauthUrl: 'http://localhost',
+    apiUrl: 'http://localhost',
     clientId: 'myclientid',
     clientSecret: 'myclientsecret',
     redirectUri: 'redirect'


### PR DESCRIPTION
As per the [docs](https://developer.starlingbank.com/docs) and kindly pointed out by @rossmeyerza (in #18), the OAuth url for exchanging tokens should be the same as the main base url. This was in the original (i.e. pre-`v1.0.0` versions) and think copied across during the migration.

I've tested this locally and with sandbox and all seems to be working smoothly.

Fixes #18