### PR TITLE
🏗️ Use npm ci instead of install in release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -13,7 +13,7 @@ fi
 rm -rf docs/ out/ dist/
 
 # install dependencies and run build
-npm install
+npm ci
 npm run build
 
 # bump the version


### PR DESCRIPTION
`npm ci` avoids changing the package.lock when installing dependencies which dirties the release commit.