### PR TITLE
STAR-41825: Restrict updates to CODEOWNERS file to repo admins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS
+
+# codeowner changes limited to repo admins
+/.github/CODEOWNERS @starlingbank/admin
+
+


### PR DESCRIPTION
Why are you making this change?
This update adds /.github/CODEOWNERS @starlingbank/admin rule to the codeowners file of this repo so that only repo admins can update the codeowners file.

What is the feature flag for this change?
Feature flag key: none

Any known issues or TODOs?
None.